### PR TITLE
Take ignoreCase into account when comparing export lists

### DIFF
--- a/lib/sortExports.js
+++ b/lib/sortExports.js
@@ -56,9 +56,9 @@ module.exports = {
 
     function isOutOfOrder(first, second) {
       if (sortDir === "desc") {
-        return first < second;
+        return handleCase(first) < handleCase(second);
       }
-      return first > second;
+      return handleCase(first) > handleCase(second);
     }
 
     function handleCase(name) {


### PR DESCRIPTION
Currently `ignoreCase` option is not not taken into account with export lists.

For example, with options `{ "ignoreCase": true }`, the following will pass
```
export { B, a, c }
```
whereas
```
export { a, B, c }
```
will complain `Expected B before a`. The value of `ignoreCase` doesn't affect the results.

This PR fixes the first example to error and the second example to pass, when  `{ "ignoreCase": true }`.