### PR TITLE
Fix rule when more than two exports exists

### DIFF
--- a/lib/sortExports.js
+++ b/lib/sortExports.js
@@ -89,6 +89,8 @@ module.exports = {
                 node,
               });
             }
+
+            previousNamedExport = currentNamedExport;
           });
         } else {
           if (isOutOfOrder(previousExport, currentExport)) {

--- a/test/sortExports.test.js
+++ b/test/sortExports.test.js
@@ -40,6 +40,9 @@ ruleTester.run("sort-exports/sort-exports", rule, {
       code: 'export {a, b} from "foo"',
     },
     {
+      code: 'export {a, b, c} from "foo"',
+    },
+    {
       code: 'export {a} from "foo"; export function b() {};',
     },
   ],
@@ -76,6 +79,10 @@ ruleTester.run("sort-exports/sort-exports", rule, {
     {
       code: 'export {b, a} from "foo"',
       errors: ["Expected a before b"],
+    },
+    {
+      code: 'export {a, c, b} from "foo"',
+      errors: ["Expected b before c"],
     },
   ],
 });


### PR DESCRIPTION
When you have more than two exports, problems appears:

```javascript
export {a, c, b} from "foo"
```
is marked as a valid export, but should be an error, the correct export order is:

```javascript
export {a, b, c} from "foo"
```