### PR TITLE
Fix ignoreCase of empty export

### DIFF
--- a/lib/sortExports.js
+++ b/lib/sortExports.js
@@ -93,7 +93,7 @@ module.exports = {
       return false;
     }
 
-    function handleCase(name) {
+    function handleCase(name = "") {
       return ignoreCase ? name.toLowerCase() : name;
     }
 

--- a/test/sortExports.test.js
+++ b/test/sortExports.test.js
@@ -66,6 +66,10 @@ ruleTester.run("sort-exports/sort-exports", rule, {
       code: "export {Baz}; export type {Bar}; export type {Foo};",
       options: [{ sortExportKindFirst: "value" }],
     },
+    {
+      code: "export {}",
+      options: [{ ignoreCase: true }],
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
In TypeScript, if a file doesn't have an import/export statement, to mark it as a module one can use

```ts
export {};
```

When that statement is analyzed by this library, the following error is thrown

```
    TypeError: Cannot read property 'toLowerCase' of undefined
    Occurred while linting <input>:1

       95 |
       96 |     function handleCase(name) {
    >  97 |       return ignoreCase ? name.toLowerCase() : name;
          |                                ^
       98 |     }
       99 |
      100 |     function exportNameAndKind(name, kind) {

      at toLowerCase (lib/sortExports.js:97:32)
      at handleCase (lib/sortExports.js:77:14)
      at isOutOfOrder (lib/sortExports.js:150:9)
      at checkDeclaration (lib/sortExports.js:166:9)
      at node_modules/eslint/lib/linter/safe-emitter.js:45:58
```

This PR fixes that error.